### PR TITLE
Fix like_operation logic

### DIFF
--- a/config.ini.example
+++ b/config.ini.example
@@ -1,7 +1,7 @@
 ;push_devicecode 从bark里面获取
 [Settings]
 collectible_name = 恶相花
-like_operation = 1
+like_operation = 2
 goods_name_1 = 恶相花
 goods_name_2 = 恶相果
 need_push = 1

--- a/gui.py
+++ b/gui.py
@@ -35,8 +35,8 @@ class ConfigEditor(ft.Container):
         self.like_operation = ft.Dropdown(
             label="点赞操作模式",
             options=[
-                ft.dropdown.Option("0", "不管点赞继续采集"),
-                ft.dropdown.Option("1", "离开点赞人物")
+                ft.dropdown.Option("1", "不管点赞继续采集"),
+                ft.dropdown.Option("2", "离开点赞人物")
             ],
             value=self.config["Settings"]["like_operation"]
         )


### PR DESCRIPTION
## Summary
- fix config option numbering for `like_operation`
- update example config

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6889d1a062248326b13a186bf9de8bdc